### PR TITLE
Document the need for a UTF8 MySQL DB character set

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -1,7 +1,13 @@
 
 # Database
 
-The app relies on a SQLite database to store statistics specifications and results.
+The app relies on a SQL database to store statistics specifications and results.
+
+## Backend DB
+
+Both SQLite and MySQL are supported. See the config to choose between the two.
+
+IMPORTANT: the MySQL DB needs to be utf8.
 
 ## Schema
 
@@ -11,7 +17,7 @@ This table holds the valid `API_key` values.
 
 Columns:
 
-* TEXT `key`
+* STRING `key` PRIMARY_KEY
 
 ### JOBS
 
@@ -19,8 +25,8 @@ This table holds both statistics specifications and results.
 
 Columns:
 
-* TEXT `id`: the API `<stat-id>`
-* TEXT `API_key`: the owner API_KEYS.`key`
+* STRING `id` PRIMARY_KEY: the API `<stat-id>`
+* STRING `API_key` PRIMARY_KEY FOREIGN_KEY: the owner API_KEYS.`key`
 * TEXT `xml_spec`: the uploaded XML job specification
 * TEXT `value`: the JSON statistics result
 * DATETIME `created`


### PR DESCRIPTION
I confirmed and reproduced that the Unicode issue is caused by the DB charset, so I documented that requirement.

The traceback is fine, just the Python 3 exception history.

All the tests have Unicode check marks in them already.
