### PR TITLE
Make numeric parsing resilient against non-castable strings

### DIFF
--- a/qualtrics_stats/generate.py
+++ b/qualtrics_stats/generate.py
@@ -180,10 +180,15 @@ class SliderQuestion(Question):
     def parse_line(self, csv_line):
         country = csv_line[self.country_column]
         if csv_line[self.column] != '99999':  # Skip unanswered sliders
-            n = float(csv_line[self.column])
-            self.general.add(n)
-            if country != '99999':
-                self.countries[country].add(n)
+            try:
+                n = float(csv_line[self.column])
+            except ValueError:
+                # If we received a value that can't be parsed as a float, log it, but then ignore the value.
+                logging.warning('Could not interpret value as number: %r', csv_line[self.column])
+            else:
+                self.general.add(n)
+                if country != '99999':
+                    self.countries[country].add(n)
 
     def as_dict(self):
         return {


### PR DESCRIPTION
Currently, `generate.py` attempts to convert every value it receives from Qualtrics to a float, without attempting to catch any errors. The problem is, Qualtrics doesn't commit to give us a castable value.

So. This PR updates the logic so that if we get a value that we can't interpret it as a number, we will log it and drop it like it's hot. And then continue on our merry way without letting it ruin our day.

Testing instructions:

This code already exists on the server, so run the crontask, and verify that it loads data, and look for warning logs about data that doesn't make sense.